### PR TITLE
add attributes for Fill, Stroke, Width & Height

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,33 +1,46 @@
 [![nuxt-icons](https://i.imgur.com/SR1XufB.png "nuxt-icons banner")](https://github.com/gitFoxCode/nuxt-icons)
+
 # Nuxt Icons
-A module for nuxt3 that allows you to use your own SVG icons quickly and enjoyably. 
+
+A module for nuxt3 that allows you to use your own SVG icons quickly and enjoyably.
 
 [![playground-usage](https://i.imgur.com/SMXXpVu.png "example of using icons in project")](https://github.com/gitFoxCode/nuxt-icons)
 
-## Installation 
+## What this module does
+
+The module retrieves all svg files from the assets/icons folder, removes the height and width from them to make them scalable, and using the `<nuxt-icon>` component allows them to be used. `<nuxt-icon>` injects the SVG code directly into `<span>`.
+
+## Features
+
+- Easy SVG icon management ✅
+- HMR (You don't have to reset the project to reload the icons) ✅
+- Ability to manipulate icons just like fonts, e.g. using `color`, `font-size` instead of `fill`,`width`,`height` ✅
+- Ability to use the original icon color scheme or custom colors for complex icons using the `fill` & `stroke` attributes ✅
+
+## Installation
+
 1. `npm i nuxt-icons`
 2. add `nuxt-icons` to modules, **nuxt.config.ts**:
+
 ```javascript
-import { defineNuxtConfig } from 'nuxt3'
+import { defineNuxtConfig } from "nuxt3";
 export default defineNuxtConfig({
-    modules: [
-        'nuxt-icons'
-      ]
-})
+  modules: ["nuxt-icons"],
+});
 ```
 
 ## Usage
+
 1. Create a `icons` folder in `assets`: `assets/icons`
 2. Drop your icons with the **.svg** extension into the `icons` folder
 3. In the project, use `<nuxt-icon name="">`, where name is the name of your svg icon from the folder
 
-If you need to use the original color from the svg file (for example, if your icon has defs) you need to use the **fill** attribute: <br>
-`<nuxt-icon name="mySuperIcon" fill />`
-
 ### Subfolders
-If you would like to use some more complicated folder arrangement you will have to use naming similar to what you may know from nuxt when creating subfolders in components. 
+
+If you would like to use some more complicated folder arrangement you will have to use naming similar to what you may know from nuxt when creating subfolders in components.
 
 If you have a svg icon in nested directories such as:
+
 ```
 📁icons
   └📁admin
@@ -35,31 +48,80 @@ If you have a svg icon in nested directories such as:
   └📁user
   ⠀⠀└ badge.svg
 ```
-then the icons's name will be based on its own path directory and filename. Therefore, the icon's name will be:
-```html
-<nuxt-icon name="AdminBadge"> and <nuxt-icon name="UserBadge">
-```
-## What this module does
-The module retrieves all svg files from the assets/icons folder, removes the height and width from them to make them scalable, and using the `<nuxt-icon>` component allows them to be used. `<nuxt-icon>` injects the SVG code directly into `<span>`. 
 
-## Features
-- Easy SVG icon management ✅
-- HMR (You don't have to reset the project to reload the icons) ✅
-- Ability to manipulate icons just like fonts, e.g. using `color`, `font-size` instead of `fill`,`width`,`height` ✅
-- Ability to use the original color scheme for complex icons using the `fill` attribute ✅
+then the icons's name will be based on its own path directory and filename. Therefore, the icon's name will be:
+
+```html
+<nuxt-icon name="AdminBadge"></nuxt-icon>
+and
+<nuxt-icon name="UserBadge"></nuxt-icon>
+```
+
+_Note: If you are using an icon pack that has sub folders, simply add the names of the subfolders into the `name` attribute_
+_For a folder structure of `Iconpack > General > Admin` you would use:_
+
+```html
+<nuxt-icon name="IconpackGeneralAdminBadge" />
+```
+
+### Attributes
+
+Attributes are available to fine tune various aspects of your icons such as `fill`, `stroke`, `width`,`height`.
+
+#### fill
+
+If you want to overwrite the original `fill` color from the svg file (for example, if your icon has defs) you need to apply the **fill** attribute:
+
+`<nuxt-icon name="mySuperIcon" fill />`
+
+The SVG's `fill` color will now be set to the text color.
+
+#### stroke
+
+If you want to overwrite the original `stroke` color from the svg file (for example, if your icon has defs) you need to apply the **fill** attribute:
+
+`<nuxt-icon name="mySuperIcon" stroke />`
+
+The SVG's `stroke` color will now be set to the text color.
+
+#### width
+
+By default, all icons are rendered with a width of `1.5rem` and an aspect ratio of 1:1. (`1.5rem` == `24px` which is the standard sizing for most icon packs)
+To set the width you need to apply the **width** attribute and give it a dimension including measuring unit:
+
+`<nuxt-icon name="mySuperIcon" width="24px" />`
+
+`<nuxt-icon name="mySuperIcon" width="2rem" />`
+
+#### height
+
+By default, all icons are rendered with a maximum height of `100%` of the containing div.
+To set the height you need to apply the **height** attribute and give it a dimension including measuring unit:
+
+`<nuxt-icon name="mySuperIcon" height="12px" />`
+
+`<nuxt-icon name="mySuperIcon" height="1rem" />`
+
+#### class
+
+All clases applied to `<nuxt-icon>` will be passed to the icon component.
+For example: To set the icon `stroke` color:
+
+`<nuxt-icon name="mySuperIcon" stroke class="myCssClass" />`
+
+_Notes: If your icon is not using 1:1 Aspect Ratio, you may need to set both `width` and `height` attributes to ensure the icon is sized correctly_
 
 ## Development
 
 - Run `npm run dev:prepare` to generate type stubs.
 - Use `npm run dev` to start [playground](./playground) in development mode.
 
-<br>
-
 ## Thoughts and ToDo's:
+
 - Ability to load icons only by component/page in order not to waste unnecessary space if the icon is not used at the time
-- Automatic svg file optimization 
+- Automatic svg file optimization
 - Automatic icon scaling that have non-square dimensions to maintain their proportions (maybe with preserveAspectRatio)
 - Usable for previous nuxt versions
-- Loading icons into symbol svg sprite *(rather worsens performance)*
+- Loading icons into symbol svg sprite _(rather worsens performance)_
 
-A big thank you to [@Diizzayy](https://github.com/Diizzayy) for his invaluable help in developing the project 
+A big thank you to [@Diizzayy](https://github.com/Diizzayy) for his invaluable help in developing the project

--- a/src/runtime/components/nuxt-icon.vue
+++ b/src/runtime/components/nuxt-icon.vue
@@ -1,38 +1,81 @@
 <template>
-  <span class="nuxt-icon" :class="{ 'nuxt-icon--fill': !fill }" v-html="icons[name]" />
+  <div class="nuxt-icon-container">
+    <div
+      class="nuxt-icon"
+      :class="{ 'nuxt-icon--fill': fill, 'nuxt-icon--stroke': stroke }"
+      :style="iconSize"
+      v-html="icons[name]"
+    />
+  </div>
 </template>
 
 <script setup>
-import { ref } from 'vue'
-import { NuxtIcons } from '#imports'
+import { ref, computed } from "vue";
+import { NuxtIcons } from "#imports";
 
 const props = defineProps({
   name: {
     type: String,
-    required: true
+    required: true,
   },
   fill: {
     type: Boolean,
     default: false,
-    required: false
-  }
-})
+    required: false,
+  },
+  stroke: {
+    type: Boolean,
+    default: false,
+    required: false,
+  },
+  width: {
+    type: String,
+    required: false,
+  },
+  height: {
+    type: String,
+    required: false,
+  },
+});
 
-const icons = ref(NuxtIcons ?? {})
+const icons = ref(NuxtIcons ?? {});
+
+const iconSize = computed(() => {
+  if (!props.width && !props.height) {
+    return "flex-basis: 1.5rem;";
+  }
+  return props.width
+    ? `width: ${props.width};`
+    : "" + props.height
+    ? `height: ${props.height};`
+    : "";
+});
 
 if (!icons.value?.[props.name]) {
-  console.error(`[nuxt-icons] Icon '${props.name}' doesn't exist in 'assets/icons'`)
+  console.error(
+    `[nuxt-icons] Icon '${props.name}' doesn't exist in 'assets/icons'`
+  );
 }
 </script>
 
 <style>
-.nuxt-icon svg{
-  width: 1em;
-  height: 1em;
-  margin-bottom: 0.125em;
-  vertical-align: middle;
+.nuxt-icon-container {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 100%;
 }
-.nuxt-icon.nuxt-icon--fill, .nuxt-icon.nuxt-icon--fill * {
+.nuxt-icon {
+  aspect-ratio: 1;
+  max-height: 100%;
+}
+.nuxt-icon.nuxt-icon--fill,
+.nuxt-icon.nuxt-icon--fill * {
   fill: currentColor !important;
+}
+
+.nuxt-icon.nuxt-icon--stroke,
+.nuxt-icon.nuxt-icon--stroke * {
+  stroke: currentColor !important;
 }
 </style>


### PR DESCRIPTION
❓ Type of change
📖 Documentation (updates to the documentation or readme)
👌 Enhancement (improving an existing functionality like performance)
 ✨ New feature (a non-breaking change that adds functionality)
 ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
📚 Description

📝 Checklist
 I have updated the documentation accordingly.
 
 ----
 
 **What did I do?**
 
1.  Add `stroke` overwrite attribute to enable changing SVG `stroke` colors
2. Reverse logic on `fill` attribute - you must specify `fill` to use the SVG's original `fill` color - Issue: https://github.com/gitFoxCode/nuxt-icons/issues/4#issue-1271564962
3. Add `width` attribute - manually specify width of SVG
4. Add `height` attribute - manually specify height of SVG
5. Set SVG `aspect-ratio` to `1:1`
6. Switched icon html to enable dynamic centering of icon on both axis
7. Updated Documentation to re-shuffle order, add info about sub-folders and provide instructions/examples for attributes

**BREAKING CHANGES**
Due to the inversion of the `fill` logic, this may cause some visual changes to icons. - Issue: https://github.com/gitFoxCode/nuxt-icons/issues/4#issue-1271564962
*Previous Behavior: if you do not set the `fill` attribute, the SVG will use it's built in colors*
*New Behavior: You must explicitly tell the SVG to use it's built in colors*
To Fix: remove `fill` from icons that already have the attribute, and add `fill` to icons that dont.


+Note: May require some additional CSS wizardry for edge cases*