### PR TITLE
fix(module): update compatibility field

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -10,7 +10,7 @@ export default defineNuxtModule<ModuleOptions>({
     name: 'nuxt-icons',
     configKey: 'NuxtIcons',
     compatibility: {
-      nuxt: '^3.0.0'
+      nuxt: '^3.0.0-rc.3'
     }
   },
   async setup (options, nuxt) {


### PR DESCRIPTION
Hi! With Nuxt 3 [RC.9](https://github.com/nuxt/framework/releases/tag/v3.0.0-rc.9) we made a change to make modules able to require minimum RC version but as a result, the `^3.0.0` is not accepted anymore. This PR fixes this. https://github.com/nuxt/framework/issues/7196