### PR TITLE
Added typescript compatibility 

### DIFF
--- a/src/runtime/components/nuxt-icon.vue
+++ b/src/runtime/components/nuxt-icon.vue
@@ -1,8 +1,9 @@
 <template>
-  <span class="nuxt-icon" :class="{ 'nuxt-icon--fill': !filled }" v-html="rawIcon" />
+  <span class="nuxt-icon" :class="{ 'nuxt-icon--fill': !filled }" v-html="icon" />
 </template>
 
 <script setup lang="ts">
+import type { Ref } from 'vue' // https://vuejs.org/guide/typescript/composition-api.html#typing-ref
 import { ref } from '#imports'
 
 const props = defineProps({
@@ -13,16 +14,14 @@ const props = defineProps({
     required: false
   }
 })
-const icon = ref('')
+const icon:Ref<Record<string, any> | string> = ref('')
 
 try {
   const iconsImport = import.meta.glob('assets/icons/**/**.svg', { as: 'raw', eager: false })
-  const rawIcon = await iconsImport[`/assets/icons/${props.name}.svg`]()
-  icon.value = rawIcon
+  icon.value = await iconsImport[`/assets/icons/${props.name}.svg`]()
 } catch {
   console.error(`[nuxt-icons] Icon '${props.name}' doesn't exist in 'assets/icons'`)
 }
-
 </script>
 
 <style>


### PR DESCRIPTION
Reasoning behind this PR: I got various errors for an existent variable being used in the template and the wrong typing for icon ref

- Fix: added typing to icon refs (either Record if the icon is present or (an empty) string if it's not); 
- Fix: it was used rawIcon instead of reactive 'icon' variable