### PR TITLE
docs: use new `nuxi module add` command in installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A module for Nuxt 3 that allows you to use your own SVG icons quickly and enjoya
 [![playground-usage](https://i.imgur.com/SMXXpVu.png "example of using icons in project")](https://github.com/gitFoxCode/nuxt-icons)
 
 ## Installation 
-1. `npm i nuxt-icons`
+1. `npx nuxi@latest module add icons
 2. add `nuxt-icons` to modules, **nuxt.config.ts**:
 ```javascript
 export default defineNuxtConfig({


### PR DESCRIPTION

This updates the documentation to use the [`nuxi module add` command](https://github.com/nuxt/cli/pull/197) which should simplify docs a bit and also improve user experience as there's no need to add to `nuxt.config` manually.

It's documented [here](https://nuxt.com/docs/api/commands/module#nuxi-module-add).

I may have missed a few spots in the documentation as I'm doing this across the modules ecosystem assisted by the power of regular expressions ✨, so I'd appreciate a review 🙏
